### PR TITLE
beautify_error_message: add a newline to the error message, in order to match wc behavior

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -49,7 +49,7 @@ fn main() {
         let file_contents = match fs::read_to_string(path) {
             Ok(x) => x,
             Err(e) => {
-                eprintln!("{:>7}: '{}': {}", "wc", path, e.to_string());
+                eprintln!("wc: {}: {}", path, e.to_string());
                 should_exit_with_err = true;
                 continue;
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -49,7 +49,7 @@ fn main() {
         let file_contents = match fs::read_to_string(path) {
             Ok(x) => x,
             Err(e) => {
-                eprint!("wc: {}: {}", path, e.to_string());
+                eprintln!("{:>7}: '{}': {}", "wc", path, e.to_string());
                 should_exit_with_err = true;
                 continue;
             }


### PR DESCRIPTION
     674    5644   35149 LICENSE
    wc: 'helo': No such file or directory (os error 2)
     152     678    4672 README.md
     826    6322   39821 total

instead of 

      674    5644   35149 LICENSE
    wc: helo: No such file or directory (os error 2)     152     678    4672 README.md
      826    6322   39821 total